### PR TITLE
fix: remove os.system() in favor of os.popen()

### DIFF
--- a/whatmp3.py
+++ b/whatmp3.py
@@ -169,19 +169,19 @@ def make_torrent(opts, target):
     if opts.verbose:
         print(torrent_cmd)
     r = system(torrent_cmd)
-    if r: failure(r, torrent_cmd)
+    if r.returncode: failure(r, torrent_cmd)
 
 def replaygain(opts, codec, outdir):
     if opts.verbose:
         print("APPLYING replaygain")
         print(encoders[enc_opts[codec]['enc']]['regain'] % outdir)
     r = system(encoders[enc_opts[codec]['enc']]['regain'] % escape_quote(outdir))
-    if r: failure(r, "replaygain")
+    if r.returncode: failure(r, "replaygain")
     for dirpath, dirs, files in os.walk(outdir, topdown=False):
         for name in dirs:
             r = system(encoders[enc_opts[codec]['enc']]['regain']
                        % os.path.join(dirpath, name))
-            if r: failure(r, "replaygain")
+            if r.returncode: failure(r, "replaygain")
 
 def setup_parser():
     p = argparse.ArgumentParser(
@@ -229,7 +229,7 @@ def setup_parser():
     return p
 
 def system(cmd):
-    return os.system(cmd)
+    return os.popen(cmd)
 
 def transcode(f, flacdir, mp3_dir, codec, opts, lock):
     tags = {}
@@ -275,7 +275,8 @@ def transcode(f, flacdir, mp3_dir, codec, opts, lock):
     if opts.verbose:
         print(flac_cmd)
     r = system(flac_cmd)
-    if r:
+    print(r.read())
+    if r.returncode:
         failure(r, "error encoding %s" % outname)
         system("touch '%s/FAILURE'" % mp3_dir)
     return 0

--- a/whatmp3.py
+++ b/whatmp3.py
@@ -150,7 +150,7 @@ def escape_percent(pattern):
     return pattern
 
 def failure(r, msg):
-    print("ERROR: %s: %s" % (r, msg), file=sys.stderr)
+    print("ERROR: %s: %s" % (os.waitstatus_to_exitcode(r), msg), file=sys.stderr)
 
 def make_torrent(opts, target):
     if opts.verbose:
@@ -169,19 +169,19 @@ def make_torrent(opts, target):
     if opts.verbose:
         print(torrent_cmd)
     r = system(torrent_cmd)
-    if r.returncode: failure(r, torrent_cmd)
+    if r: failure(r, torrent_cmd)
 
 def replaygain(opts, codec, outdir):
     if opts.verbose:
         print("APPLYING replaygain")
         print(encoders[enc_opts[codec]['enc']]['regain'] % outdir)
     r = system(encoders[enc_opts[codec]['enc']]['regain'] % escape_quote(outdir))
-    if r.returncode: failure(r, "replaygain")
+    if r: failure(r, "replaygain")
     for dirpath, dirs, files in os.walk(outdir, topdown=False):
         for name in dirs:
             r = system(encoders[enc_opts[codec]['enc']]['regain']
                        % os.path.join(dirpath, name))
-            if r.returncode: failure(r, "replaygain")
+            if r: failure(r, "replaygain")
 
 def setup_parser():
     p = argparse.ArgumentParser(
@@ -229,7 +229,8 @@ def setup_parser():
     return p
 
 def system(cmd):
-    return os.popen(cmd)
+    p = os.popen(cmd)
+    return p.close()
 
 def transcode(f, flacdir, mp3_dir, codec, opts, lock):
     tags = {}
@@ -276,7 +277,7 @@ def transcode(f, flacdir, mp3_dir, codec, opts, lock):
         print(flac_cmd)
     r = system(flac_cmd)
     print(r.read())
-    if r.returncode:
+    if r:
         failure(r, "error encoding %s" % outname)
         system("touch '%s/FAILURE'" % mp3_dir)
     return 0

--- a/whatmp3.py
+++ b/whatmp3.py
@@ -276,7 +276,6 @@ def transcode(f, flacdir, mp3_dir, codec, opts, lock):
     if opts.verbose:
         print(flac_cmd)
     r = system(flac_cmd)
-    print(r.read())
     if r:
         failure(r, "error encoding %s" % outname)
         system("touch '%s/FAILURE'" % mp3_dir)


### PR DESCRIPTION
Using whatmp3 inside torrent-done-script for Transmission on NixOS leads to 32512 errors.
The giveaway for what the problem could be was that removing all runtime dependencies led to additional error 'metaflac not found', which didn't appear previously. This got me looking at the source code for any difference between the calls to metaflac and flac/lame, that being one is called with os.popen() and the rest with os.system().
Using os.popen() gives expected results.